### PR TITLE
Absolute paths in file lists

### DIFF
--- a/DataCollection.py
+++ b/DataCollection.py
@@ -38,11 +38,12 @@ class DataCollection(object):
     '''
 
 
-    def __init__(self, infile = None, nprocs = -1):
+    def __init__(self, infile = None, nprocs = -1,useRelativePaths=True):
         '''
         Constructor
         '''
         self.clear()
+        self.useRelativePaths=useRelativePaths
         self.nprocs = nprocs       
         self.meansnormslimit=500000 
         if infile:
@@ -274,8 +275,11 @@ class DataCollection(object):
         lines = [line.rstrip('\n') for line in open(file)]
         for line in lines:
             if len(line) < 1: continue
-            self.originRoots.append(fdir+'/'+line)
-    
+            if self.useRelativePaths:
+                self.originRoots.append(fdir+'/'+line)
+            else:
+                self.originRoots.append(line)
+
         if len(self.originRoots)<1:
             raise Exception('root samples list empty')
         

--- a/bin/convertFromRoot.py
+++ b/bin/convertFromRoot.py
@@ -39,6 +39,7 @@ class_options = dict((str(i).split("'")[1].split('.')[-1], i) for i in class_opt
 
 parser = ArgumentParser('program to convert root tuples to traindata format')
 parser.add_argument("-i", help="set input sample description (output from the check.py script)", metavar="FILE")
+parser.add_argument("--noRelativePaths", help="Assume input samples are absolute paths with respect to working directory", default=False, action="store_true")
 parser.add_argument("-o",  help="set output path", metavar="PATH")
 parser.add_argument("-c",  choices = class_options.keys(), help="set output class (options: %s)" % ', '.join(class_options.keys()), metavar="Class")
 parser.add_argument("-r",  help="set path to snapshot that got interrupted", metavar="FILE", default='')
@@ -78,7 +79,8 @@ if outPath:
     logging.info("outPath = %s" % outPath)
 
 # MAIN BODY #
-dc = DataCollection(nprocs = (1 if args.nothreads else -1))  
+dc = DataCollection(nprocs = (1 if args.nothreads else -1), 
+                    useRelativePaths=True if not args.noRelativePaths else False)  
 if len(nchilds):
     dc.nprocs=int(nchilds)  
 


### PR DESCRIPTION
@jkiesele maybe this is useful, otherwise convertFromRoot.py assumes relative paths with respect to the working directory