### PR TITLE
Adapting makefile to override with CMSSW-based setup

### DIFF
--- a/compiled/Makefile
+++ b/compiled/Makefile
@@ -1,14 +1,22 @@
 # location of the Python header files
- 
+
 PYTHON_VERSION = 2.7
-PYTHON_INCLUDE = ${CONDA_PREFIX}/include/python2.7
- 
 # location of the Boost Python include files and library
- 
+PYTHON_INCLUDE = ${CONDA_PREFIX}/include/python2.7
+PYTHON_LIB=${CONDA_PREFIX}/lib/python$(PYTHON_VERSION)/config
 # also works on gpu in compiled version
 # this is just luck, ...
 BOOST_INC = ${CONDA_PREFIX}/include
 BOOST_LIB = ${CONDA_PREFIX}/lib
+ifdef CMSSW_BASE
+	PYTHON_BASE=$(shell scram tool info python | grep BASE | cut -d "=" -f 2)
+	PYTHON_INCLUDE=${PYTHON_BASE}/include/python${PYTHON_VERSION}/
+	PYTHON_LIB=${PYTHON_BASE}/lib/python${PYTHON_VERSION}/config
+	BOOST_BASE=$(shell scram tool info boost | grep BASE | cut -d "=" -f 2)
+	BOOST_INC = ${BOOST_BASE}/include
+	BOOST_LIB = ${BOOST_BASE}/lib
+endif
+
 LINUXADD=-Wl,--export-dynamic
 ROOTSTUFF=`root-config --cflags --libs --glibs` -g
 CFLAGS=
@@ -34,14 +42,13 @@ libquicklz.so:
 
 obj/%.o: src/%.cpp
 	g++ $(CFLAGS) $(ROOTSTUFF) -I./interface -O2 -fPIC -c -o $@ $< 
-    
+
 #pack helpers in lib
 libdeepjetcorehelpers.so: $(OBJ_FILES)
 	g++ -shared $(LINUXADD)  $(ROOTSTUFF) obj/*.o -o $@ 
-  
 
 %.so: %.o libdeepjetcorehelpers.so libquicklz.so
-	g++ -shared $(LINUXADD)  $(ROOTSTUFF) -lquicklz -L./ -ldeepjetcorehelpers -L$(BOOST_LIB)  -lboost_python -L${CONDA_PREFIX}/lib/python$(PYTHON_VERSION)/config -lpython2.7  $< -o $(@) 
+	g++ -shared $(LINUXADD)  $(ROOTSTUFF) -lquicklz -L./ -ldeepjetcorehelpers -L$(BOOST_LIB)  -lboost_python -L$(PYTHON_LIB) -lpython2.7  $< -o $(@) 
 
 
 %.o: src/%.C 
@@ -50,6 +57,3 @@ libdeepjetcorehelpers.so: $(OBJ_FILES)
 
 clean: 
 	rm -f $(OBJ_FILES) $(SHARED_LIBS) $(MODULES_SHARED_LIBS) $(MODULES_OBJ_FILES) libdeepjetcorehelpers.so libquicklz.so
-	
-	
-	


### PR DESCRIPTION
Tested in CMSSW_10_2_0_pre5, only required a change in the Makefile for the precompiled objects