### PR TITLE
to make the convert process the full list, and one fix in Pedro's update

### DIFF
--- a/DataCollection.py
+++ b/DataCollection.py
@@ -408,11 +408,11 @@ class DataCollection(object):
             traind=None):
         import copy
         self.readFromFile(collectionfile)
-        self.dataclass.remove=False
-        self.dataclass.weight=True #False
         if traind: 
             print('[createTestDataForDataCollection] dataclass is overriden by user request')
             self.dataclass=traind
+        self.dataclass.remove=False
+        self.dataclass.weight=True #False
         self.readRootListFromFile(inputfile)
         self.createDataFromRoot(
             self.dataclass, outputDir, False,

--- a/DataCollection.py
+++ b/DataCollection.py
@@ -668,7 +668,8 @@ class DataCollection(object):
                     #immediately send the next
                     continue
                   
-                    
+
+                results = sorted(results, key=lambda x:x[0])    
                 for r in results:
                     thisidx=r[0]
                     if thisidx==lastindex+1:


### PR DESCRIPTION
@pfs In the W recoil training, Pedro and I had the same issue as https://github.com/DL4Jets/DeepJetCore/issues/12, which seems to come from https://github.com/DL4Jets/DeepJetCore/blob/master/DataCollection.py#L672
i.e., the index in results is not always the same as r[0]. Add a sorting results before calling __collectWriteInfo should fix the problem. And one minor fix to Pedro's update.