### PR TITLE
Add bin/make_example_data_overlap to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ __pycache__
 #*.*#
 build/
 *.egg-info/
+bin/make_example_data_overlap
+


### PR DESCRIPTION
After setting things up, `bin/make_example_data_overlap` makes the repo "dirty", so I put it into the ignore list.