### PR TITLE
prevent lastcounter from shuffling the filelist

### DIFF
--- a/DataCollection.py
+++ b/DataCollection.py
@@ -838,7 +838,7 @@ class DataCollection(object):
                     self.shuffleseed=0
                 #startRead(self.nextcounter,readfilename,self.shuffleseed)
                 self.tdopen[self.nextcounter]=True
-                self.filecounter=self.__increment(self.filecounter,self.nfiles)
+                self.filecounter=self.__increment(self.filecounter,self.nfiles,to_shuffle=True)
                 self.nextcounter=self.__increment(self.nextcounter,self.nfiles)
                 
                 
@@ -854,11 +854,12 @@ class DataCollection(object):
                 self.lastcounter=self.__increment(self.lastcounter,self.nfiles)
                 return td
                 
-            def __increment(self,counter,maxval):
+            def __increment(self,counter,maxval,to_shuffle):
                 counter+=1
                 if counter>=maxval:
-                    counter=0   
-                    self.filelist = shuffle(self.filelist)
+                    counter=0
+                    if to_shuffle:
+                        self.filelist = shuffle(self.filelist)
                 return counter 
             
             def __del__(self):

--- a/DataCollection.py
+++ b/DataCollection.py
@@ -854,7 +854,7 @@ class DataCollection(object):
                 self.lastcounter=self.__increment(self.lastcounter,self.nfiles)
                 return td
                 
-            def __increment(self,counter,maxval,to_shuffle):
+            def __increment(self,counter,maxval,to_shuffle=False):
                 counter+=1
                 if counter>=maxval:
                     counter=0


### PR DESCRIPTION
Right now both lastcounter and filecounter shuffle the filelist when they get reset. Since they are staggered it means that filecounter first shuffles, and starts loading files. Then when lastcounter reaches the number of files, it reshuffles the filelist, which means you can get the same file twice in one epoch.

unfortunately not the cause of issue https://github.com/DL4Jets/DeepJetCore/issues/28