### PR TITLE
fix empty batch

### DIFF
--- a/compiled/interface/trainDataGenerator.h
+++ b/compiled/interface/trainDataGenerator.h
@@ -441,6 +441,7 @@ trainData<T>  trainDataGenerator<T>::prepareBatch(){
     size_t bufferelements=buffer_store.nElements();
     size_t expect_batchelements = splits_.at(batchcount_);
     bool usebatch = true;
+    
     if(usebatch_.size())
         usebatch = usebatch_.at(batchcount_);
 
@@ -479,6 +480,10 @@ trainData<T>  trainDataGenerator<T>::prepareBatch(){
     }
 
     auto thisbatch = buffer_store.split(expect_batchelements);
+    if(thisbatch.nTotalElements() < 1){
+      //not sure why this can happen, there might be some bigger problem here. This at least prevents crashes.
+      return prepareBatch();
+    }
 
     if(debug)
         std::cout << "providing batch " << nsamplesprocessed_ << "-" << nsamplesprocessed_+expect_batchelements <<


### PR DESCRIPTION
Issue https://github.com/DL4Jets/DeepJetCore/issues/38 comes from  buffer_store.split(expect_batchelements) returning an empty batch despite the buffer_store being seemingly full. It seems to happen only at the first batch of an epoch. 

What seems to work it, is just trying to prepare the batch again. However there might be some underlying problem here that is being ignored, im not sure.