### PR TITLE
Fix layer freeze

### DIFF
--- a/modeltools.py
+++ b/modeltools.py
@@ -20,9 +20,11 @@ def printLayerInfosAndWeights(model, noweights=False):
 
 
 def fixLayersContaining(m, fixOnlyContaining, invert=False):
-    isseq=(not hasattr(fixOnlyContaining, "strip") and
-            hasattr(fixOnlyContaining, "__getitem__") or
-            hasattr(fixOnlyContaining, "__iter__"))
+    import collections.abc
+    if isinstance(fixOnlyContaining, collections.abc.Sequence) and not isinstance(fixOnlyContaining, str):
+        isseq=True
+    else:
+        isseq=False
     if not isseq:
         fixOnlyContaining=[fixOnlyContaining]
     if invert:
@@ -34,7 +36,7 @@ def fixLayersContaining(m, fixOnlyContaining, invert=False):
                     m.get_layer(index=layidx).trainable=True
     else:
         for layidx in range(len(m.layers)):
-            for ident in fixOnlyContaining:
+            for ident in fixOnlyContaining:    
                 if len(ident) and ident in m.get_layer(index=layidx).name:
                     m.get_layer(index=layidx).trainable=False
     return m


### PR DESCRIPTION
This trick for checking if it is a sequence, is now true also for a string in python3, which breaks the freeze layer function.

We also use it in
https://github.com/DL4Jets/DeepJetCore/blob/master/evaluation/evaluation.py#L60 , but i am not sure if it is a problem there.